### PR TITLE
Bubble width

### DIFF
--- a/ProductTour/ProductTour/CRBubble.m
+++ b/ProductTour/ProductTour/CRBubble.m
@@ -147,11 +147,17 @@
     float height = CR_PADDING*3;
     float width = CR_PADDING*3;
     
-    CGRect stringRect = [self.title boundingRectWithSize:CGSizeMake([UIScreen mainScreen].bounds.size.width, CR_TITLE_FONT_SIZE)
-                                                 options:NSStringDrawingUsesLineFragmentOrigin
-                                              attributes:@{ NSFontAttributeName:[UIFont fontWithName:fontName size:CR_TITLE_FONT_SIZE] }
-                                                 context:nil];
-    float titleWidth = stringRect.size.width;
+    float titleWidth = 0;
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+        CGRect stringRect = [self.title boundingRectWithSize:CGSizeMake([UIScreen mainScreen].bounds.size.width, CR_TITLE_FONT_SIZE)
+                                                     options:NSStringDrawingUsesLineFragmentOrigin
+                                                  attributes:@{ NSFontAttributeName:[UIFont fontWithName:fontName size:CR_TITLE_FONT_SIZE] }
+                                                     context:nil];
+        titleWidth = stringRect.size.width;
+    }
+    else {
+        titleWidth = [self.title length]*CR_TITLE_FONT_SIZE/2.5;
+    }
     
     if(self.title && ![self.title isEqual:@""])
     {
@@ -161,11 +167,19 @@
     height-=CR_DESCRIPTION_FONT_SIZE;
     float descriptionWidth=0;
     for (NSString *descriptionLine in  stringArray) {
-        CGRect stringRect = [descriptionLine boundingRectWithSize:CGSizeMake([UIScreen mainScreen].bounds.size.width, CR_DESCRIPTION_FONT_SIZE)
-                                                          options:NSStringDrawingUsesLineFragmentOrigin
-                                                       attributes:@{ NSFontAttributeName:[UIFont systemFontOfSize:CR_DESCRIPTION_FONT_SIZE] }
-                                                          context:nil];
-        float stringWidth = stringRect.size.width;
+        
+        float stringWidth = 0;
+        if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+            CGRect stringRect = [descriptionLine boundingRectWithSize:CGSizeMake([UIScreen mainScreen].bounds.size.width, CR_DESCRIPTION_FONT_SIZE)
+                                                              options:NSStringDrawingUsesLineFragmentOrigin
+                                                           attributes:@{ NSFontAttributeName:[UIFont systemFontOfSize:CR_DESCRIPTION_FONT_SIZE] }
+                                                              context:nil];
+            stringWidth = stringRect.size.width;
+        }
+        else {
+            stringWidth = [descriptionLine length]*CR_DESCRIPTION_FONT_SIZE/2.1;
+        }
+        
         if (descriptionWidth < stringWidth)
             descriptionWidth = stringWidth;
         height+=CR_DESCRIPTION_FONT_SIZE;


### PR DESCRIPTION
Hey,

I fixed the bubble width to be exactly what is supposed to be by using boundingRectWithSize iOS 7 methods  !

Now you can see on the example the width of the bubble is perfect, whatever if the font is custom or not.
